### PR TITLE
Pass -target and -mios-simulator-version to C/C++ code

### DIFF
--- a/.github/workflows/build-openjdk-sim.yml
+++ b/.github/workflows/build-openjdk-sim.yml
@@ -62,5 +62,7 @@ jobs:
           --with-sysroot=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk \
           --with-libffi-include=$(realpath ../../support/include/ffi) \
           --with-libffi-lib=$(realpath ../../support) \
+          --with-extra-cflags="-target arm64-apple-ios-simulator -mios-simulator-version-min=18.2" \
+          --with-extra-cxxflags="-target arm64-apple-ios-simulator -mios-simulator-version-min=18.2" \
           --with-cups-include=$(xcrun --sdk macosx --show-sdk-path)/usr/include
           make LOG=cmdlines,info CONF=iossim-aarch64-zero-release static-libs-image


### PR DESCRIPTION
Required to get the correct meta info in object files and libraries (LC_BUILD_VERSION etc)

Fix #20